### PR TITLE
reset hugo webhook and update cron scheduling

### DIFF
--- a/.github/workflows/rebuilds.yml
+++ b/.github/workflows/rebuilds.yml
@@ -2,10 +2,10 @@
 name: Crontab Rebuilds
 
 on:
-  schedule:
-    - cron: "0  9 * * *" # daily at 09am
-    - cron: "0 17 * * *" # daily at 05pm
-    - cron: "0  1 * * *" # daily at 01am
+  schedule:  # crontab times are in UTC
+    - cron: "0 14 * * *" # daily at 09am EST
+    - cron: "0 22 * * *" # daily at 05pm EST
+    - cron: "0  6 * * *" # daily at 01am EST
 
 jobs:
   crontab-rebuild:
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: curl Request
-        run: curl -X POST -d {} ${{ secrets.HUGO_MIGRATION_BUILD_HOOK }}
+        run: curl -X POST -d {} ${{ secrets.netlify_hugo_webhook }}


### PR DESCRIPTION
- changed the default branch we use – so crontab needs new webhook secret.
- also realized `cron` runs on UTC time, so we need to shift to EST.